### PR TITLE
chore: update @clerk/react-router to v3.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "clerk-react-router-quickstart",
       "dependencies": {
-        "@clerk/react-router": "^3.0.1",
+        "@clerk/react-router": "^3.0.7",
         "@react-router/node": "7.12.0",
         "@react-router/serve": "7.12.0",
         "isbot": "^5.1.31",
@@ -491,12 +491,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.0.1.tgz",
-      "integrity": "sha512-U5E+KpNlFlaJRdpOoOltIV8o1YjTWw5affsugEb/kIvGceSP6SzvNEBr/TnCY+2yu87Vq22ShEycpQBlse2Bkw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.3.tgz",
+      "integrity": "sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.0.0",
+        "@clerk/shared": "^4.3.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -505,12 +505,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.0.1.tgz",
-      "integrity": "sha512-zq6vfH7Yiul4PPxUmyl/iW6CZbIzxfHvhXLxZK9zbqHQEy9xDlIQirhWIiHucBqMWTJruudY5KCV5WBe2xmfww==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.1.3.tgz",
+      "integrity": "sha512-9t5C8eM5cTmOmpBO5nb8FDA40biQqeQLUW+cVwAE0t5hnGRwiC6mSv83vqHg+9qQBqtliR013BGVjpCz53gVCA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.0.0",
+        "@clerk/shared": "^4.3.2",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -522,15 +522,15 @@
       }
     },
     "node_modules/@clerk/react-router": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@clerk/react-router/-/react-router-3.0.1.tgz",
-      "integrity": "sha512-ktZMSgKBElQTCgBHqqWeKXgWAR1B0k3PFbc+tQz5rtXu5M/Lh4zv2x5vvB0H2c1oCpSRhoTz2qBt3V56c+V67g==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@clerk/react-router/-/react-router-3.0.7.tgz",
+      "integrity": "sha512-SXVvJedWxiDrn6kT11msnLkJjCeEFWKqaxZMSdsEb9woqswetdcaKGe2n0Q887J2wEh9cUYMwbj9/YRBclu9ZA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.0.1",
-        "@clerk/react": "^6.0.1",
-        "@clerk/shared": "^4.0.0",
-        "cookie": "0.7.2",
+        "@clerk/backend": "^3.2.3",
+        "@clerk/react": "^6.1.3",
+        "@clerk/shared": "^4.3.2",
+        "cookie": "1.0.2",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -542,10 +542,19 @@
         "react-router": "^7.9.0"
       }
     },
+    "node_modules/@clerk/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@clerk/shared": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.0.0.tgz",
-      "integrity": "sha512-Z3QhVud7FM9SBgSGxyUdC+nDg6vro+5zJ5gDO1To3FDzRLWKW4xIGd5y8UBqWZMMMHWaSDiZvYlUynb+gs8PnQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.3.2.tgz",
+      "integrity": "sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@clerk/react-router": "^3.0.1",
+    "@clerk/react-router": "^3.0.7",
     "@react-router/node": "7.12.0",
     "@react-router/serve": "7.12.0",
     "isbot": "^5.1.31",


### PR DESCRIPTION
## Summary
- Update `@clerk/react-router` from v3.0.1 to v3.0.7

## Test plan
- [x] `npm run build` passes
