### PR TITLE
chore: update @clerk/react-router to v3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "clerk-react-router-quickstart",
       "dependencies": {
-        "@clerk/react-router": "^3.0.7",
+        "@clerk/react-router": "^3.1.2",
         "@react-router/node": "7.12.0",
         "@react-router/serve": "7.12.0",
         "isbot": "^5.1.31",
@@ -491,12 +491,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.3.tgz",
-      "integrity": "sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.12.tgz",
+      "integrity": "sha512-pTuD3+3IvLrjx9XMYdbqpttTltrWc7npxkOIDzhtID5/+IOomxZAzsnxU1G1hvOeBoR1Jl68ZgKQw66aZ+DRFQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.3.2",
+        "@clerk/shared": "^4.8.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -505,12 +505,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.1.3.tgz",
-      "integrity": "sha512-9t5C8eM5cTmOmpBO5nb8FDA40biQqeQLUW+cVwAE0t5hnGRwiC6mSv83vqHg+9qQBqtliR013BGVjpCz53gVCA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.4.2.tgz",
+      "integrity": "sha512-l43pon5wcM0n4e3gnRP7MWdvAXAa3M7BOF6aeNwEuITxgy6MU6ypej9tPeGmXxPicL/Hd6E/VRgiEipEKDqyCQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.3.2",
+        "@clerk/shared": "^4.8.2",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -522,14 +522,14 @@
       }
     },
     "node_modules/@clerk/react-router": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@clerk/react-router/-/react-router-3.0.7.tgz",
-      "integrity": "sha512-SXVvJedWxiDrn6kT11msnLkJjCeEFWKqaxZMSdsEb9woqswetdcaKGe2n0Q887J2wEh9cUYMwbj9/YRBclu9ZA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@clerk/react-router/-/react-router-3.1.2.tgz",
+      "integrity": "sha512-mYv1rplcPtbzzmgSZYxzyc3Bjiv2gtrmv59wklJx47Cb0TIPqLAiNHaCZqgTLSCwd4W3F1OuMo35FDHFZzIHmA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.3",
-        "@clerk/react": "^6.1.3",
-        "@clerk/shared": "^4.3.2",
+        "@clerk/backend": "^3.2.12",
+        "@clerk/react": "^6.4.2",
+        "@clerk/shared": "^4.8.2",
         "cookie": "1.0.2",
         "tslib": "2.8.1"
       },
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.3.2.tgz",
-      "integrity": "sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
+      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@clerk/react-router": "^3.0.7",
+    "@clerk/react-router": "^3.1.2",
     "@react-router/node": "7.12.0",
     "@react-router/serve": "7.12.0",
     "isbot": "^5.1.31",


### PR DESCRIPTION
## Summary
- Updates `@clerk/react-router` from `^3.0.7` to `^3.1.2` (latest)

## Test plan
- [x] `npm run build` passes
