### PR TITLE
chore: ignore .env*.local in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env
+.env*.local
 /node_modules/
 
 # React Router


### PR DESCRIPTION
## Summary

The repo's `.gitignore` ignored `.env` but not `.env.local`. Since `clerk env pull` writes keys to `.env.local`, that file showed up as **untracked but un-ignored** — a contributor could accidentally commit the secret key.

## Changes

- Add `.env*.local` to `.gitignore`, matching the Vercel/Next.js default. This covers `.env.local`, `.env.development.local`, `.env.production.local`, etc.

## Not Planned

- A broader `.env*` catch-all (with `!.env.example`) was considered but skipped. The Vercel CLI force-appends `.env*.local` to `.gitignore` regardless, so pairing it with `.env*` just produces a redundant, auto-injected duplicate. Matching exactly what the tooling writes avoids that churn, and `.env.local` is the only secret-bearing file this quickstart produces.

## References

- Fixes [DOCS-11864](https://linear.app/clerk/issue/DOCS-11864/clerk-react-router-quickstart-gitignore-does-not-ignore-envlocal)
